### PR TITLE
Simplify front-end layout and styles

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -1,54 +1,18 @@
-:root {
-  color-scheme: light dark;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background-color: #0b0c10;
-  color: #f5f7fa;
-}
-
-* {
-  box-sizing: border-box;
-}
-
 body {
   margin: 0;
-  min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(36, 64, 142, 0.45), transparent 55%),
-    radial-gradient(circle at bottom, rgba(197, 63, 120, 0.35), transparent 60%), #11131a;
+  padding: 1.5rem;
 }
 
-.page {
+main {
   max-width: 960px;
   margin: 0 auto;
-  padding: 3rem 1.5rem 4rem;
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.5rem;
 }
 
-.page__header h1 {
-  margin: 0 0 0.25rem;
-  font-size: clamp(1.5rem, 2.6vw, 2.4rem);
-  letter-spacing: 0.02em;
-}
-
-.page__header p {
-  margin: 0;
-  color: rgba(245, 247, 250, 0.75);
-}
-
-.player {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.player__video {
+#video-wrapper {
   position: relative;
-  width: 100%;
-  background: rgba(255, 255, 255, 0.05);
-  border-radius: 1rem;
-  overflow: hidden;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
 }
 
 #source-video {
@@ -58,214 +22,102 @@ body {
   background: #000;
 }
 
-.selection-overlay {
+#selection-overlay {
   position: absolute;
   inset: 0;
   pointer-events: none;
 }
 
-.selection-overlay.hidden {
-  opacity: 0;
+.hidden {
+  display: none;
 }
 
 .selection-rect {
   position: absolute;
-  border: 3px solid rgba(255, 255, 255, 0.85);
-  box-shadow: 0 10px 18px rgba(0, 0, 0, 0.35);
-  backdrop-filter: blur(2px);
-  background: rgba(21, 24, 32, 0.25);
-  border-radius: 12px;
+  border: 2px solid #000;
+  background: rgba(255, 255, 255, 0.15);
   cursor: grab;
   pointer-events: auto;
   touch-action: none;
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
 .selection-rect:active {
   cursor: grabbing;
-  box-shadow: 0 14px 24px rgba(0, 0, 0, 0.45);
-  transform: scale(1.01);
 }
 
-.selection-rect__label {
+.selection-rect span {
   position: absolute;
-  top: 8px;
-  left: 12px;
+  top: 0.25rem;
+  left: 0.25rem;
   font-size: 0.85rem;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  text-transform: uppercase;
-  padding: 0.1rem 0.6rem;
-  border-radius: 999px;
-  background: rgba(10, 13, 26, 0.8);
-  color: rgba(255, 255, 255, 0.92);
-  pointer-events: none;
+  background: #fff;
+  padding: 0.1rem 0.3rem;
 }
 
 .selection-rect__handle {
   position: absolute;
-  width: 22px;
-  height: 22px;
-  border-radius: 6px;
-  background: rgba(255, 255, 255, 0.9);
-  border: 2px solid rgba(10, 13, 26, 0.35);
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  width: 14px;
+  height: 14px;
+  background: #fff;
+  border: 1px solid #000;
   pointer-events: auto;
-  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23101624' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M4 12h16'/%3E%3Cpath d='M8 8l-4 4 4 4'/%3E%3Cpath d='M16 8l4 4-4 4'/%3E%3C/svg%3E");
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: 70%;
 }
 
 .selection-rect__handle--top-left {
   top: 0;
   left: 0;
-  transform: translate(-50%, -50%) rotate(45deg);
+  transform: translate(-50%, -50%);
   cursor: nwse-resize;
 }
 
 .selection-rect__handle--top-right {
   top: 0;
   right: 0;
-  transform: translate(50%, -50%) rotate(-45deg);
+  transform: translate(50%, -50%);
   cursor: nesw-resize;
 }
 
 .selection-rect__handle--bottom-left {
   bottom: 0;
   left: 0;
-  transform: translate(-50%, 50%) rotate(-45deg);
+  transform: translate(-50%, 50%);
   cursor: nesw-resize;
 }
 
 .selection-rect__handle--bottom-right {
   bottom: 0;
   right: 0;
-  transform: translate(50%, 50%) rotate(45deg);
+  transform: translate(50%, 50%);
   cursor: nwse-resize;
 }
 
-.actions {
+#feedback {
+  min-height: 1.2rem;
+  font-weight: 600;
+}
+
+#exports {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
-  align-items: flex-start;
-}
-
-.button {
-  border: none;
-  background: linear-gradient(135deg, #5f5ce6, #9b5cf6);
-  color: #fff;
-  padding: 0.75rem 1.5rem;
-  border-radius: 999px;
-  font-size: 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
-}
-
-.button:disabled {
-  opacity: 0.6;
-  cursor: wait;
-}
-
-.button:not(:disabled):hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px rgba(91, 92, 241, 0.35);
-}
-
-.hint {
-  margin: 0;
-  font-size: 0.9rem;
-  color: rgba(245, 247, 250, 0.65);
-}
-
-.feedback {
-  min-height: 1.2rem;
-  font-weight: 500;
-}
-
-.feedback--pending {
-  color: #f6c744;
-}
-
-.feedback--success {
-  color: #58f093;
-}
-
-.feedback--warning {
-  color: #f6c744;
-}
-
-.feedback--error {
-  color: #ff7a7a;
-}
-
-.exports {
-  display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 0.75rem;
 }
 
 .exports__item {
-  padding: 1rem;
-  border-radius: 0.85rem;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid #000;
+  padding: 0.75rem;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-}
-
-.exports__item h3 {
-  margin: 0;
-  font-size: 1.05rem;
-}
-
-.exports__item p {
-  margin: 0;
-  color: rgba(245, 247, 250, 0.7);
+  gap: 0.25rem;
 }
 
 .download {
-  color: #9ec5ff;
-  text-decoration: none;
-  font-weight: 600;
+  color: inherit;
 }
 
 .download:hover {
   text-decoration: underline;
 }
 
-.empty-state {
-  padding: 2rem;
-  border-radius: 1rem;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-}
-
-.empty-state p {
-  margin: 0;
-  color: rgba(245, 247, 250, 0.75);
-}
-
-code {
-  background: rgba(255, 255, 255, 0.08);
-  padding: 0.15rem 0.35rem;
-  border-radius: 4px;
-  font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", monospace;
-  font-size: 0.9rem;
-}
-
-@media (max-width: 600px) {
-  .page {
-    padding: 2rem 1rem 3rem;
-  }
-
-  .button {
-    width: 100%;
-    justify-content: center;
-  }
+section > p {
+  max-width: 40rem;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,37 +7,35 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}" />
   </head>
   <body>
-    <main class="page">
-      <header class="page__header">
-        <h1>Podcast Vertical Cropper</h1>
-        <p>Select the frames that will build the two-person vertical video.</p>
-      </header>
+    <main>
+      <h1>Podcast Vertical Cropper</h1>
+      <p>Select the frames that will build the two-person vertical video.</p>
 
       {% if video_url %}
-      <section class="player">
-        <div class="player__video" id="video-wrapper">
+      <section>
+        <div id="video-wrapper">
           <video id="source-video" controls crossorigin="anonymous">
             <source src="{{ video_url }}" type="{{ video_mime }}" />
             Your browser does not support the video tag.
           </video>
-          <div class="selection-overlay hidden" id="selection-overlay">
-            <div class="selection-rect" id="rect-speaker-1">
-              <span class="selection-rect__label">Speaker 1</span>
+          <div id="selection-overlay" class="hidden">
+            <div id="rect-speaker-1" class="selection-rect">
+              <span>Speaker 1</span>
             </div>
-            <div class="selection-rect" id="rect-speaker-2">
-              <span class="selection-rect__label">Speaker 2</span>
+            <div id="rect-speaker-2" class="selection-rect">
+              <span>Speaker 2</span>
             </div>
           </div>
         </div>
-        <div class="actions">
-          <button id="confirm-selection" type="button" class="button">Export speaker clips</button>
-          <p class="hint">Rectangles keep a 1.1:1 format for vertical stacking.</p>
+        <div>
+          <button id="confirm-selection" type="button">Export speaker clips</button>
+          <p>Rectangles keep a 1.1:1 format for vertical stacking.</p>
         </div>
-        <div id="feedback" class="feedback" role="status" aria-live="polite"></div>
-        <div id="exports" class="exports"></div>
+        <div id="feedback" role="status" aria-live="polite"></div>
+        <div id="exports"></div>
       </section>
       {% else %}
-      <section class="empty-state">
+      <section>
         <p>No video found. Drop a podcast recording in <code>data/raw</code> and refresh this page.</p>
       </section>
       {% endif %}


### PR DESCRIPTION
## Summary
- replace the template markup with semantic elements that rely on built-in browser styling while keeping the functional IDs intact
- collapse the stylesheet to only provide minimal layout, overlay, and export list structure with neutral borders and native controls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e7c4b590e8832ebb75ab7ef670fe27